### PR TITLE
Firefox Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/
 node_modules/
+web-ext-artifacts

--- a/image-viewer.js
+++ b/image-viewer.js
@@ -1398,6 +1398,7 @@ window.ImageViewer = (function () {
         dragFlag = true
         lastPos.x = e.clientX
         lastPos.y = e.clientY
+        e.preventDefault()
       })
       li.addEventListener('mousemove', e => {
         if (!dragFlag) return

--- a/image-viewer.js
+++ b/image-viewer.js
@@ -1395,10 +1395,10 @@ window.ImageViewer = (function () {
       let finalDragTimeout = 0
       const lastPos = {x: 0, y: 0}
       li.addEventListener('mousedown', e => {
+        e.preventDefault()
         dragFlag = true
         lastPos.x = e.clientX
         lastPos.y = e.clientY
-        e.preventDefault()
       })
       li.addEventListener('mousemove', e => {
         if (!dragFlag) return

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,8 @@
   "permissions": ["storage", "contextMenus", "scripting", "webNavigation"],
   "host_permissions": ["*://*/*", "file:///*"],
   "background": {
-    "scripts": ["background.js"]
+    "scripts": ["background.js"],
+    "service_worker": "background.js"
   },
   "options_page": "/page/options.html",
   "action": {

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
   "permissions": ["storage", "contextMenus", "scripting", "webNavigation"],
   "host_permissions": ["*://*/*", "file:///*"],
   "background": {
-    "service_worker": "background.js"
+    "scripts": ["background.js"]
   },
   "options_page": "/page/options.html",
   "action": {


### PR DESCRIPTION
Hiya! This is what works on Firefox (with a warning) and Chrome! In the future, Firefox will support service workers, but until then, two manifests are required it seems: One for Chrome, one for Firefox

### For just Firefox builds (to fix the warning message):
```json
  "background": {
    "scripts": ["background.js"]
  },